### PR TITLE
Issue 15/databricks repo property

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,16 @@ _This is the maven databricks plugin, which uses the databricks rest api._
 How to build the project locally:
 ```mvn clean install```
 
+- Not required! Because you can build and develop without it, but you will likely want Lombok configured with your IDEA:
+https://projectlombok.org/setup/intellij
+
 How to run the project locally (if applicable):
 
 
 ## Running the tests
 
 ```mvn clean test```
+
 
 ### End-to-End testing
 
@@ -30,7 +34,7 @@ export DB_USER=myuser
 export DB_PASSWORD=mypassword
 export DB_URL=my-test-db-instance
 export DB_TOKEN=my-db-token
-export DB_REPO=my-s3-bucket
+export DB_REPO=my-s3-bucket/my-artifact-location
 export INSTANCE_PROFILE_ARN=arn:aws:iam::123456789:instance-profile/MyDatabricksRole
 ```
 
@@ -49,12 +53,6 @@ Since this code is a library, you do not need to deploy it anywhere, once it pas
 
 ## Configuring
 
-You will want a property somewhere in your pom with this value which represents
-where on s3 you want to store your artifacts:
-```xml
-<databricks.repo>edmunds-repos/artifacts</databricks.repo>
-```
-
 It is recommended that you use maven profiles to allow for credentials per an environment to be defined.
 ```xml
          <!-- Databricks QA Credentials -->
@@ -67,7 +65,7 @@ It is recommended that you use maven profiles to allow for credentials per an en
                          <artifactId>databricks-maven-plugin</artifactId>
                          <version>${oss-databricks-maven-plugin-version}</version>
                          <configuration>
-                             <bucketName>${databricks.repo}</bucketName>
+                             <databricksRepo>${which bucket you want to use to store databricks artifacts}</databricksRepo>
                              <!-- This is used to be able to allow for conditional configuration in job settings -->
                              <environment>QA</environment>
                              <host>${qa-host-here}</host>
@@ -155,7 +153,7 @@ Note that this file is a template, that has access to both the java system prope
     //If you emit this section, it will automatically be added to your job
     "libraries": [
       {
-        "jar": "s3://${projectProperties['databricks.repo']}/artifacts/${groupId}/${artifactId}/${version}/${artifactId}-${version}.jar"
+        "jar": "s3://${projectProperties['databricks.repo']}/${projectProperties['databricks.repo.key']}"
       }
    ],
   "email_notifications" : {
@@ -179,6 +177,10 @@ mvn databricks:upsert-job
 
 #deploys a specific version
 mvn databricks:upsert-job -Ddeploy-version=1.0
+
+#you don't want validation! 
+#If so, it could be good to create an issue and let us know where our validation rules are too specific
+mvn databricks:upsert-job -Dvalidate=false
 ```
 
 You can use freemarker templating like so:

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.edmunds</groupId>
     <artifactId>databricks-maven-plugin</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.1-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
 
@@ -78,20 +78,14 @@
 
         <freemarker-version>2.3.22</freemarker-version>
         <aws-java-sdk-s3-version>1.11.347</aws-java-sdk-s3-version>
-        <httpcomponents-version>4.4.1</httpcomponents-version>
-        <commons-codec-version>1.11</commons-codec-version>
         <commons-lang-version>3.4</commons-lang-version>
         <commons-collections-version>3.2.1</commons-collections-version>
 
-        <maven-javadoc-plugin-version>2.10.2</maven-javadoc-plugin-version>
-        <maven-plugin-info-version>3.0.0</maven-plugin-info-version>
-        <maven-site-plugin-version>3.7</maven-site-plugin-version>
-        <maven-plugin-plugin-version>3.5.2</maven-plugin-plugin-version>
-        <maven-version>3.2.1</maven-version>
-        <maven-plugin-annotation-version>3.2</maven-plugin-annotation-version>
+        <maven-version>3.2.5</maven-version>
+        <maven-plugin-annotation-version>3.3</maven-plugin-annotation-version>
         <plexus-version>3.0.24</plexus-version>
 
-        <databricks-rest-client-version>[2.0.0, 2.1.0)</databricks-rest-client-version>
+        <databricks-rest-client-version>[2.2.0, 2.3.0)</databricks-rest-client-version>
 
         <!--Test versions-->
         <hamcrest-version>1.3</hamcrest-version>
@@ -101,17 +95,18 @@
         <groovy-version>2.4.15</groovy-version>
     </properties>
 
+
     <reporting>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>${maven-plugin-plugin-version}</version>
+                <version>3.5.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${maven-plugin-info-version}</version>
+                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -150,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin-version}</version>
+                <version>2.10.2</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -179,6 +174,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
+                    <!--<parallel>none</parallel>-->
+                    <!--<forkCount>1</forkCount>-->
+                    <!--<reuseForks>false</reuseForks>-->
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
@@ -189,18 +187,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>${maven-site-plugin-version}</version>
+                <version>3.7</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${maven-plugin-info-version}</version>
+                <version>3.0.0</version>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>${maven-plugin-plugin-version}</version>
+                <version>3.5.2</version>
                 <configuration>
                     <goalPrefix>databricks</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
@@ -323,7 +321,7 @@
                         </executions>
                         <dependencies>
                             <dependency>
-                                <groupId>com.edmunds.databricks</groupId>
+                                <groupId>com.edmunds</groupId>
                                 <artifactId>databricks-rest-client</artifactId>
                                 <version>${databricks-rest-client-version}</version>
                             </dependency>
@@ -341,7 +339,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.edmunds.databricks</groupId>
+            <groupId>com.edmunds</groupId>
             <artifactId>databricks-rest-client</artifactId>
             <version>${databricks-rest-client-version}</version>
         </dependency>
@@ -391,6 +389,7 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- TEST DEPENDENCIES-->
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
@@ -431,6 +430,48 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${groovy-version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.sisu</groupId>
+            <artifactId>org.eclipse.sisu.plexus</artifactId>
+            <version>0.3.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.sonatype.sisu</groupId>
+            <artifactId>sisu-guice</artifactId>
+            <version>3.2.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-aether-provider</artifactId>
+            <version>${maven-version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven-version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${maven-version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/it/simple-it/pom.xml
+++ b/src/it/simple-it/pom.xml
@@ -29,8 +29,6 @@
         <pmd.skip>true</pmd.skip>
         <cpd.skip>true</cpd.skip>
         <skipTests>true</skipTests>
-        <bucketName>${env.DB_REPO}</bucketName>
-        <databricks.repo>${env.DB_REPO}</databricks.repo>
         <instance.profile.arn>${env.INSTANCE_PROFILE_ARN}</instance.profile.arn>
         <environment>QA</environment>
     </properties>
@@ -62,6 +60,9 @@
                 <groupId>@project.groupId@</groupId>
                 <artifactId>@project.artifactId@</artifactId>
                 <version>@project.version@</version>
+                <configuration>
+                    <databricksRepo>${env.DB_REPO}</databricksRepo>
+                </configuration>
                 <executions>
                     <execution>
                         <id>prepackage</id>

--- a/src/it/simple-it/setup.groovy
+++ b/src/it/simple-it/setup.groovy
@@ -23,7 +23,7 @@ import com.edmunds.rest.databricks.service.WorkspaceService
 //TODO couldn't use the Environment class here?
 def databricksIntegrationTestJobName = "bde.tools.integration-test/databricks-maven-plugin-stream-it/QA"
 def databricksServiceFactory = DatabricksServiceFactory.Builder
-        .createServiceFactoryWithUserPasswordAuthentication(System.getenv("DB_USER"), System.getenv("DB_PASSWORD"), System.getenv("DB_URL")).build();
+        .createUserPasswordAuthentication(System.getenv("DB_USER"), System.getenv("DB_PASSWORD"), System.getenv("DB_URL")).build();
 def jobService = databricksServiceFactory.getJobService()
 def workspaceService = databricksServiceFactory.workspaceService
 

--- a/src/it/simple-it/src/main/resources/databricks-plugin/databricks-job-settings.json
+++ b/src/it/simple-it/src/main/resources/databricks-plugin/databricks-job-settings.json
@@ -32,7 +32,7 @@
       "parameters": [
         "--class",
         "com.edmunds.HelloWorld",
-        "s3://${projectProperties['databricks.repo']}/artifacts/${groupId}/${artifactId}/${version}/${artifactId}-${version}.jar",
+        "s3://${projectProperties['databricks.repo']}/${projectProperties['databricks.repo.key']}",
         "${projectProperties['build.time']}"
       ]
     },

--- a/src/it/simple-it/verify.groovy
+++ b/src/it/simple-it/verify.groovy
@@ -29,7 +29,7 @@ import org.apache.commons.lang3.StringUtils
 
 //TODO couldn't use the Environment class here?
 def databricksServiceFactory = DatabricksServiceFactory.Builder
-        .createServiceFactoryWithUserPasswordAuthentication(System.getenv("DB_USER"), System.getenv("DB_PASSWORD"), System.getenv("DB_URL")).build();
+        .createUserPasswordAuthentication(System.getenv("DB_USER"), System.getenv("DB_PASSWORD"), System.getenv("DB_URL")).build();
 def jobService = databricksServiceFactory.getJobService()
 def databricksIntegrationTestJobName = "bde.tools.integration-test/databricks-maven-plugin-stream-it/QA"
 
@@ -52,7 +52,7 @@ private JobDTO validateJob(JobService jobService, String databricksIntegrationTe
     def jarPath = parameters[parameters.length - 2]
 
     def repoPath = System.getenv("DB_REPO")
-    assert jarPath == "s3://" + repoPath + "/artifacts/com.edmunds.bde.tools.integration-test/databricks-maven-plugin-stream-it/1.0-SNAPSHOT/databricks-maven-plugin-stream-it-1.0-SNAPSHOT.jar"
+    assert jarPath == "s3://" + repoPath + "/com.edmunds.bde.tools.integration-test/databricks-maven-plugin-stream-it/1.0-SNAPSHOT/databricks-maven-plugin-stream-it-1.0-SNAPSHOT.jar"
 
     /**
      * We set a build time property in the pom, that passes through to the job config, which passes through to databricks.

--- a/src/main/java/com/edmunds/tools/databricks/maven/BaseDatabricksJobMojo.java
+++ b/src/main/java/com/edmunds/tools/databricks/maven/BaseDatabricksJobMojo.java
@@ -142,6 +142,11 @@ public abstract class BaseDatabricksJobMojo extends BaseDatabricksMojo {
 
             // [BDD-3114] - we want the current environment, to honor what was passed into the build, and not what was serialized [SAE]
             jobTemplateModel.setEnvironment(environment);
+            if (StringUtils.isBlank(databricksRepo)) {
+                throw new MojoExecutionException("missing property: databricks.repo");
+            }
+            jobTemplateModel.getProjectProperties().setProperty("databricks.repo", databricksRepo);
+            jobTemplateModel.getProjectProperties().setProperty("databricks.repo.key", databricksRepoKey);
 
             return jobTemplateModel;
         } catch (IOException e) {
@@ -272,7 +277,8 @@ public abstract class BaseDatabricksJobMojo extends BaseDatabricksMojo {
                     , jobName, OBJECT_MAPPER.writeValueAsString(defaultDTO.getEmailNotifications())));
 
         } else if (targetDTO.getEmailNotifications().getOnFailure() == null
-                || StringUtils.isEmpty(targetDTO.getEmailNotifications().getOnFailure()[0])) {
+                || targetDTO.getEmailNotifications().getOnFailure().length == 0
+            || StringUtils.isEmpty(targetDTO.getEmailNotifications().getOnFailure()[0])) {
             targetDTO.getEmailNotifications().setOnFailure(defaultDTO.getEmailNotifications().getOnFailure());
             getLog().info(String.format("%s|set email_notifications.on_failure with %s"
                     , jobName, OBJECT_MAPPER.writeValueAsString(defaultDTO.getEmailNotifications().getOnFailure())));

--- a/src/main/java/com/edmunds/tools/databricks/maven/PrepareLibraryResources.java
+++ b/src/main/java/com/edmunds/tools/databricks/maven/PrepareLibraryResources.java
@@ -2,19 +2,17 @@ package com.edmunds.tools.databricks.maven;
 
 import com.edmunds.tools.databricks.maven.model.LibraryClustersModel;
 import com.edmunds.tools.databricks.maven.util.ObjectMapperUtils;
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.maven.artifact.Artifact;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-
-import static org.apache.commons.lang3.StringUtils.defaultString;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Prepares the library-mapping.json file such that we can run library attachment, sans project later (e.g. during a build).
@@ -22,7 +20,6 @@ import static org.apache.commons.lang3.StringUtils.defaultString;
 @Mojo(name = "prepare-library-resources", requiresProject = true, defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
 public class PrepareLibraryResources extends BaseWorkspaceMojo {
 
-    public static final String DEFAULT_DBFS_ROOT_FORMAT = "s3://%s";
 
     public static final String JAR = "jar";
 
@@ -43,19 +40,12 @@ public class PrepareLibraryResources extends BaseWorkspaceMojo {
     @Parameter(property = "version", defaultValue = "${project.version}")
     protected String version;
 
-    /**
-     * The root dbfs folder to use
-     */
-    @Parameter(property = "dbfsRoot")
-    protected String dbfsRoot;
-
     @Override
     public void execute() throws MojoExecutionException {
         prepareLibraryResources();
     }
 
     void prepareLibraryResources() throws MojoExecutionException {
-
         if (project.getArtifact().getType().equals(JAR)) {
             if (ArrayUtils.isNotEmpty(clusters)) {
                 try {
@@ -89,29 +79,4 @@ public class PrepareLibraryResources extends BaseWorkspaceMojo {
             throw new MojoExecutionException(e.getMessage(), e);
         }
     }
-
-    String createArtifactPath() {
-        dbfsRoot = defaultString(dbfsRoot, String.format(DEFAULT_DBFS_ROOT_FORMAT, project.getProperties().getProperty("databricks.repo")));
-
-        Artifact artifact = project.getArtifact();
-        String artifactId = artifact.getArtifactId();
-        String fileName = String.format("%s-%s.%s", artifactId, version, artifact.getType());
-
-        return String.format("%s/artifacts/%s/%s/%s/%s", dbfsRoot, project.getGroupId(), artifactId, version, fileName);
-    }
-
-    /**
-     * NOTE - only for unit testing!
-     */
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    /**
-     * NOTE - only for unit testing!
-     */
-    public void setDbfsRoot(String dbfsRoot) {
-        this.dbfsRoot = dbfsRoot;
-    }
-
 }

--- a/src/main/java/com/edmunds/tools/databricks/maven/UpsertJobMojo.java
+++ b/src/main/java/com/edmunds/tools/databricks/maven/UpsertJobMojo.java
@@ -21,6 +21,7 @@ import com.edmunds.rest.databricks.DTO.JobSettingsDTO;
 import com.edmunds.rest.databricks.DatabricksRestException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 

--- a/src/main/resources/default-job.json
+++ b/src/main/resources/default-job.json
@@ -1,7 +1,7 @@
 [
   // Full example: Be careful when editing the full example, it is used for default!
   {
-    "name": "${groupWithoutCompany}/${artifactId}/${environment}",
+    "name": "${groupWithoutCompany}/${artifactId}",
     "new_cluster": {
       "spark_version": "4.2.x-scala2.11",
       "aws_attributes": {
@@ -20,7 +20,7 @@
     },
     "libraries": [
       {
-        "jar": "s3://${projectProperties['databricks.repo']}/artifacts/${groupId}/${artifactId}/${version}/${artifactId}-${version}.jar"
+        "jar": "s3://${projectProperties['databricks.repo']}/${projectProperties['databricks.repo.key']}"
       }
     ],
     "email_notifications": {

--- a/src/test/java/com/edmunds/tools/databricks/maven/BetterAbstractMojoTestCase.java
+++ b/src/test/java/com/edmunds/tools/databricks/maven/BetterAbstractMojoTestCase.java
@@ -1,0 +1,101 @@
+/*
+ *        Taken from https://github.com/ahgittin/license-audit-maven-plugin
+ *
+ *        Licensed under the Apache License, Version 2.0 (the "License");
+ *        you may not use this file except in compliance with the License.
+ *        You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *        Unless required by applicable law or agreed to in writing, software
+ *        distributed under the License is distributed on an "AS IS" BASIS,
+ *        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *        See the License for the specific language governing permissions and
+ *        limitations under the License.
+ */
+package com.edmunds.tools.databricks.maven;
+
+import org.apache.maven.DefaultMaven;
+import org.apache.maven.Maven;
+import org.apache.maven.execution.*;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
+
+import java.io.File;
+import java.util.Arrays;
+
+/**
+ * Borrowed from <strong>ahgittin</strong> to provide a working Maven project as part of unit testing.
+ *
+ * @author ahgittin (https://github.com/ahgittin/license-audit-maven-plugin)
+ */
+public abstract class BetterAbstractMojoTestCase extends AbstractMojoTestCase {
+
+    protected MavenSession newMavenSession() {
+        try {
+            MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+            MavenExecutionResult result = new DefaultMavenExecutionResult();
+
+            // populate sensible defaults, including repository basedir and remote repos
+            MavenExecutionRequestPopulator populator;
+            populator = getContainer().lookup(MavenExecutionRequestPopulator.class);
+            populator.populateDefaults(request);
+
+            // this is needed to allow java profiles to get resolved; i.e. avoid during project builds:
+            // [ERROR] Failed to determine Java version for profile java-1.5-detected @ org.apache.commons:commons-parent:22, /Users/alex/.m2/repository/org/apache/commons/commons-parent/22/commons-parent-22.pom, line 909, column 14
+            request.setSystemProperties(System.getProperties());
+
+            // and this is needed so that the repo session in the maven session
+            // has a repo manager, and it points at the local repo
+            // (cf MavenRepositorySystemUtils.newSession() which is what is otherwise done)
+            DefaultMaven maven = (DefaultMaven) getContainer().lookup(Maven.class);
+            DefaultRepositorySystemSession repoSession =
+                (DefaultRepositorySystemSession) maven.newRepositorySession(request);
+            repoSession.setLocalRepositoryManager(
+                new SimpleLocalRepositoryManagerFactory().newInstance(repoSession,
+                    new LocalRepository(request.getLocalRepository().getBasedir())));
+
+            @SuppressWarnings("deprecation")
+            MavenSession session = new MavenSession(getContainer(),
+                repoSession,
+                request, result);
+            return session;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Extends the super to use the new {@link #newMavenSession()} introduced here
+     * which sets the defaults one expects from maven; the standard test case leaves a lot of things blank
+     */
+    @Override
+    protected MavenSession newMavenSession(MavenProject project) {
+        MavenSession session = newMavenSession();
+        session.setCurrentProject(project);
+        session.setProjects(Arrays.asList(project));
+        return session;
+    }
+
+    /**
+     * As {@link #lookupConfiguredMojo(MavenProject, String)} but taking the pom file
+     * and creating the {@link MavenProject}.
+     */
+    protected Mojo lookupConfiguredMojo(File pom, String goal) throws Exception {
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+
+        ProjectBuildingRequest buildingRequest = newMavenSession().getProjectBuildingRequest();
+        ProjectBuilder projectBuilder = lookup(ProjectBuilder.class);
+        MavenProject project = projectBuilder.build(pom, buildingRequest).getProject();
+
+        return lookupConfiguredMojo(project, goal);
+    }
+
+}

--- a/src/test/java/com/edmunds/tools/databricks/maven/BetterAbstractMojoTestCase.java
+++ b/src/test/java/com/edmunds/tools/databricks/maven/BetterAbstractMojoTestCase.java
@@ -1,17 +1,181 @@
 /*
  *        Taken from https://github.com/ahgittin/license-audit-maven-plugin
  *
- *        Licensed under the Apache License, Version 2.0 (the "License");
- *        you may not use this file except in compliance with the License.
- *        You may obtain a copy of the License at
- *
- *            http://www.apache.org/licenses/LICENSE-2.0
- *
- *        Unless required by applicable law or agreed to in writing, software
- *        distributed under the License is distributed on an "AS IS" BASIS,
- *        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *        See the License for the specific language governing permissions and
- *        limitations under the License.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
  */
 package com.edmunds.tools.databricks.maven;
 

--- a/src/test/java/com/edmunds/tools/databricks/maven/DatabricksMavenPluginTestHarness.java
+++ b/src/test/java/com/edmunds/tools/databricks/maven/DatabricksMavenPluginTestHarness.java
@@ -1,0 +1,94 @@
+/*
+ *    Copyright 2018 Edmunds.com, Inc.
+ *
+ *        Licensed under the Apache License, Version 2.0 (the "License");
+ *        you may not use this file except in compliance with the License.
+ *        You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *        Unless required by applicable law or agreed to in writing, software
+ *        distributed under the License is distributed on an "AS IS" BASIS,
+ *        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *        See the License for the specific language governing permissions and
+ *        limitations under the License.
+ */
+
+package com.edmunds.tools.databricks.maven;
+
+import com.edmunds.rest.databricks.DatabricksServiceFactory;
+import com.edmunds.rest.databricks.service.ClusterService;
+import com.edmunds.rest.databricks.service.DbfsService;
+import com.edmunds.rest.databricks.service.JobService;
+import com.edmunds.rest.databricks.service.LibraryService;
+import com.edmunds.rest.databricks.service.WorkspaceService;
+import org.apache.log4j.Logger;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.File;
+
+import static org.powermock.api.mockito.PowerMockito.when;
+
+
+/**
+ * Any test that extends this class requires that the plugin descriptor is available in order for this test to run.
+ * If you do mvn clean install, you should then be able to run tests that depend on this class.
+ * Unfortunately, some changes to MOJO will require that you regenerate this plugin descriptor.
+ */
+public abstract class DatabricksMavenPluginTestHarness extends BetterAbstractMojoTestCase {
+
+    @Mock
+    protected DatabricksServiceFactory databricksServiceFactory;
+    @Mock
+    protected ClusterService clusterService;
+    @Mock
+    protected LibraryService libraryService;
+    @Mock
+    protected WorkspaceService workspaceService;
+    @Mock
+    protected JobService jobService;
+    @Mock
+    protected DbfsService dbfsService;
+
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void beforeMethod() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(databricksServiceFactory.getClusterService()).thenReturn(clusterService);
+        when(databricksServiceFactory.getLibraryService()).thenReturn(libraryService);
+        when(databricksServiceFactory.getWorkspaceService()).thenReturn(workspaceService);
+        when(databricksServiceFactory.getJobService()).thenReturn(jobService);
+        when(databricksServiceFactory.getDbfsService()).thenReturn(dbfsService);
+    }
+
+    public <T extends BaseDatabricksMojo> T getNoOverridesMojo(String goal) throws Exception {
+        File testPom = new File(getBasedir(),
+            String.format("src/test/resources/unit/basic-test/%s/test-no-overrides-plugin-config" +
+                ".xml", goal));
+        T ret = (T) lookupConfiguredMojo(testPom, goal);
+        ret.setDatabricksServiceFactory(databricksServiceFactory);
+        return ret;
+    }
+
+    public <T extends BaseDatabricksMojo> T getMissingMandatoryMojo(String goal) throws Exception {
+        File testPom = new File(getBasedir(),
+            String.format("src/test/resources/unit/basic-test/%s/test-missing-mandatory-plugin-config" +
+                ".xml", goal));
+
+        T ret = (T) lookupConfiguredMojo(testPom, goal);
+        ret.setDatabricksServiceFactory(databricksServiceFactory);
+        return ret;
+    }
+
+    public <T extends BaseDatabricksMojo> T getOverridesMojo(String goal) throws Exception {
+        File testPom = new File(getBasedir(),
+            String.format("src/test/resources/unit/basic-test/%s/test-overrides-plugin-config" +
+                ".xml", goal));
+        T ret = (T) lookupConfiguredMojo(testPom, goal);
+        ret.setDatabricksServiceFactory(databricksServiceFactory);
+        return ret;
+    }
+}

--- a/src/test/java/com/edmunds/tools/databricks/maven/LibraryMojoTest.java
+++ b/src/test/java/com/edmunds/tools/databricks/maven/LibraryMojoTest.java
@@ -16,6 +16,7 @@
 
 package com.edmunds.tools.databricks.maven;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -23,9 +24,10 @@ import org.testng.annotations.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class PrepareLibraryResourcesTest extends DatabricksMavenPluginTestHarness {
+//Requires building beforehand??
+public class LibraryMojoTest extends DatabricksMavenPluginTestHarness {
 
-    private final String GOAL = "prepare-library-resources";
+    private final String GOAL = "library";
 
     @BeforeClass
     public void initClass() throws Exception {
@@ -37,24 +39,28 @@ public class PrepareLibraryResourcesTest extends DatabricksMavenPluginTestHarnes
         super.beforeMethod();
     }
 
+    //TODO actually test the library functionality!
     @Test
     public void testCreateArtifactPath_default() throws Exception {
-        PrepareLibraryResources underTest = (PrepareLibraryResources) getNoOverridesMojo(GOAL);
+        LibraryMojo underTest = (LibraryMojo) getNoOverridesMojo(GOAL);
         assertThat(underTest.createArtifactPath(), is("s3://my-bucket/artifacts/unit-test-group" +
                 "/unit-test-artifact/1.0.0-SNAPSHOT/unit-test-artifact-1.0.0-SNAPSHOT.jar"));
-        //TODO actually test the execute here
-        underTest.execute();
     }
 
     @Test
-    public void testCreateArtifactPath_doesNothingWhenNoFieldsSpecified() throws Exception {
-        PrepareLibraryResources underTest = (PrepareLibraryResources) getMissingMandatoryMojo(GOAL);
-        underTest.execute();
+    public void testCreateArtifactPath_failsWhenMissingMandatoryFields() throws Exception {
+        LibraryMojo underTest = (LibraryMojo) getMissingMandatoryMojo(GOAL);
+        try {
+            underTest.execute();
+        } catch (MojoExecutionException e) {
+            return;
+        }
+        fail();
     }
 
     @Test
     public void testCreateArtifactPath_succeedsWithOverrides() throws Exception {
-        PrepareLibraryResources underTest = (PrepareLibraryResources) getOverridesMojo(GOAL);
+        LibraryMojo underTest = (LibraryMojo) getOverridesMojo(GOAL);
         assertThat(underTest.createArtifactPath(), is("s3://my-bucket/artifacts/my-destination"));
     }
 }

--- a/src/test/java/com/edmunds/tools/databricks/maven/UploadMojoTest.java
+++ b/src/test/java/com/edmunds/tools/databricks/maven/UploadMojoTest.java
@@ -1,0 +1,91 @@
+/*
+ *    Copyright 2018 Edmunds.com, Inc.
+ *
+ *        Licensed under the Apache License, Version 2.0 (the "License");
+ *        you may not use this file except in compliance with the License.
+ *        You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *        Unless required by applicable law or agreed to in writing, software
+ *        distributed under the License is distributed on an "AS IS" BASIS,
+ *        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *        See the License for the specific language governing permissions and
+ *        limitations under the License.
+ */
+
+package com.edmunds.tools.databricks.maven;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for @{@link UpsertJobMojo}.
+ * <p>
+ * For these tests, the regex as part of the expected exceptions no longer works.
+ */
+public class UploadMojoTest extends DatabricksMavenPluginTestHarness {
+
+    private final String GOAL = "upload-to-s3";
+
+    private UploadMojo underTest;
+
+    private ClassLoader classLoader = UploadMojoTest.class.getClassLoader();
+
+    @Mock
+    AmazonS3Client s3Client;
+
+    @BeforeClass
+    public void initClass() throws Exception {
+        super.setUp();
+    }
+
+    @BeforeMethod
+    public void beforeMethod() throws Exception {
+        super.beforeMethod();
+        underTest = getNoOverridesMojo(GOAL);
+    }
+
+    @Test
+    public void testDefaultExecute() throws MojoExecutionException {
+        underTest.s3Client = s3Client;
+        underTest.execute();
+    }
+
+    @Test
+    public void testMissingProperties() throws Exception {
+        underTest = getMissingMandatoryMojo(GOAL);
+        underTest.s3Client = s3Client;
+        try {
+            underTest.execute();
+        } catch (MojoExecutionException e) {
+            assertThat(e.getMessage(), containsString("Missing mandatory parameter: ${databricksRepo}"));
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void testOverridesExecute() throws Exception {
+        underTest = getOverridesMojo(GOAL);
+        underTest.s3Client = s3Client;
+        underTest.execute();
+
+        ArgumentCaptor<PutObjectRequest> putRequestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        Mockito.verify(s3Client).putObject(putRequestCaptor.capture());
+        assertEquals("myBucket", putRequestCaptor.getValue().getBucketName());
+        assertEquals("repo/unit-test-group/unit-test-artifact/1.0.0-SNAPSHOT/unit-test-artifact-1.0.0-SNAPSHOT.jar",
+            putRequestCaptor.getValue().getKey());
+        assertEquals("myFile.csv", putRequestCaptor.getValue().getFile().getName());
+    }
+}

--- a/src/test/java/com/edmunds/tools/databricks/maven/validation/ValidationUtilTest.java
+++ b/src/test/java/com/edmunds/tools/databricks/maven/validation/ValidationUtilTest.java
@@ -31,6 +31,9 @@ import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link ValidationUtil}.
+ *
+ * BE VERY CAREFUL WITH SYSTEM PROPERTIES. THIS CAN CAUSE OTHER TESTS TO FAIL THAT DEPEND ON SYSTEM PROPERTIES TO BE
+ * SET.
  */
 public class ValidationUtilTest {
 
@@ -57,7 +60,8 @@ public class ValidationUtilTest {
 
     @Test
     public void testValidPath_with_maven() throws Exception {
-        System.getProperties().clear();
+        System.setProperty(ARTIFACT_ID, "");
+        System.setProperty(GROUP_ID, "");
         validatePath("/maven-group-id/maven-artifact-id", mavenProject.getGroupId(), mavenProject.getArtifactId());
 
         //nothing to assert, failure will throw an exception
@@ -73,7 +77,8 @@ public class ValidationUtilTest {
 
     @Test(expectedExceptions = MojoExecutionException.class, expectedExceptionsMessageRegExp = ".*'groupId' is not set.*")
     public void testMissingGroupId() throws Exception {
-        System.getProperties().clear();
+        System.setProperty(ARTIFACT_ID, "");
+        System.setProperty(GROUP_ID, "");
         when(mavenProject.getGroupId()).thenReturn("");
 
         validatePath("/maven-group-id/maven-artifact-id", mavenProject.getGroupId(), mavenProject.getArtifactId());
@@ -81,7 +86,8 @@ public class ValidationUtilTest {
 
     @Test(expectedExceptions = MojoExecutionException.class, expectedExceptionsMessageRegExp = ".*'artifactId' is not set.*")
     public void testMissingArtifactId() throws Exception {
-        System.getProperties().clear();
+        System.setProperty(ARTIFACT_ID, "");
+        System.setProperty(GROUP_ID, "");
         when(mavenProject.getArtifactId()).thenReturn("");
 
         validatePath("/maven-group-id/maven-artifact-id", mavenProject.getGroupId(), mavenProject.getArtifactId());

--- a/src/test/resources/unit/basic-test/library/test-missing-mandatory-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/library/test-missing-mandatory-plugin-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration></configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-library-resources</goal>
+                            <goal>library</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/library/test-no-overrides-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/library/test-no-overrides-plugin-config.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <databricksRepo>my-bucket/artifacts</databricksRepo>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-library-resources</goal>
+                            <goal>library</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/library/test-overrides-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/library/test-overrides-plugin-config.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <databricksRepo>my-bucket/artifacts</databricksRepo>
+                    <databricksRepoKey>my-destination</databricksRepoKey>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-library-resources</goal>
+                            <goal>library</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/prepare-library-resources/test-missing-mandatory-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/prepare-library-resources/test-missing-mandatory-plugin-config.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-library-resources</goal>
+                            <goal>library</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/prepare-library-resources/test-no-overrides-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/prepare-library-resources/test-no-overrides-plugin-config.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <databricksRepo>my-bucket/artifacts</databricksRepo>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-library-resources</goal>
+                            <goal>library</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/prepare-library-resources/test-overrides-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/prepare-library-resources/test-overrides-plugin-config.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <databricksRepo>my-bucket/artifacts</databricksRepo>
+                    <databricksRepoKey>my-destination</databricksRepoKey>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-library-resources</goal>
+                            <goal>library</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/upload-to-s3/test-missing-mandatory-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/upload-to-s3/test-missing-mandatory-plugin-config.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <file>myFile.csv</file>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>upload-to-s3</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/upload-to-s3/test-no-overrides-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/upload-to-s3/test-no-overrides-plugin-config.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <databricksRepo>my-bucket</databricksRepo>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>upload-to-s3</goal>
+                        </goals>
+                        <configuration></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/upload-to-s3/test-overrides-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/upload-to-s3/test-overrides-plugin-config.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <file>myFile.csv</file>
+                    <databricksRepo>myBucket/repo</databricksRepo>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>upload-to-s3</goal>
+                        </goals>
+                        <configuration></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/upsert-job/src/main/resources/databricks-plugin/databricks-job-settings.json
+++ b/src/test/resources/unit/basic-test/upsert-job/src/main/resources/databricks-plugin/databricks-job-settings.json
@@ -1,0 +1,18 @@
+[
+  {
+    "email_notifications": {
+      "on_failure": ["myfakeemail.com"]
+    },
+    "spark_jar_task": {
+      "main_class_name": "",
+      "parameters": []
+    },
+    "timeout_seconds": 1800,
+    // If streaming job, timeout_seconds should override to 0
+    "retry_on_timeout": false,
+    "max_retries": 0,
+    //0 : never retry, -1: indefinitely
+    "min_retry_interval_millis": 120000,
+    "max_concurrent_runs": 1
+  }
+]

--- a/src/test/resources/unit/basic-test/upsert-job/test-missing-mandatory-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/upsert-job/test-missing-mandatory-plugin-config.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>upsert-job</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/upsert-job/test-no-overrides-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/upsert-job/test-no-overrides-plugin-config.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <environment>QA</environment>
+                    <databricksRepo>my-bucket</databricksRepo>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>upsert-job</goal>
+                        </goals>
+                        <configuration></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/upsert-job/test-overrides-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/upsert-job/test-overrides-plugin-config.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2018 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <environment>QA</environment>
+                    <databricksRepo>my-bucket</databricksRepo>
+                    <dbJobFile>my-job.json</dbJobFile>
+                    <validate>false</validate>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>upsert-job</goal>
+                        </goals>
+                        <configuration></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
This PR resolves #15

Primary Goal
The goal of this change is to get get rid of the bucketName property in favor of databricks.repo property. I have also cleaned up similar properties to keep things DRY and named them to be consistent. I had to keep databricks.repo rather then bucketName due to the fact that it is riddled around our job settings files currently.

Secondary Goal
In making these changes, I realized that it will be very useful going forward to be able to test the default property settings used by MOJOs instead of setting it as part of the test. I now have a harness that should make this easy going forward. I would recommend that an issue is opened to migrate all existing tests to use the harness.

Dependencies
This actually depends on an upgrade to databricks-rest-client which has already been released.

Tech Debt
Tests: The LibraryMojoTest and PrepareLibraryMojoTest are not complete.

Testing
This was tested via unit-tests, the integration test and finally a manual test with one of our modules.

Backwards Compatibility
The biggest change is the modification of the databricks.repo name to databricksRepo. In our case, this property was only set once in parent pom of our projects, but it is a change that should be clearly stated. Because not many people used the bucketName property and key property, I do not believe that this will cause too many issues.