### PR TITLE
[BDD-3877] - running upsert-cluster without a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,12 @@ By default cluster config should be located at
 ```bash
 ${project.build.resources[0].directory}/databricks-plugin/databricks-cluster-settings.json
 ```
-but you can override the location:
+but you can overwrite the location:
 ```bash
 mvn databricks:upsert-cluster -DdbClusterFile=${project.build.resources[0].directory}/my.json
 ```
+And also you ought to do it in case of out-of-project plugin usage.
+
 Note that you can simultaneously manage multiple clusters with a single .json file.
 All configurations will be applied at once in a parallel manner.  
 

--- a/src/main/java/com/edmunds/tools/databricks/maven/UpsertClusterMojo.java
+++ b/src/main/java/com/edmunds/tools/databricks/maven/UpsertClusterMojo.java
@@ -53,7 +53,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 /**
  * Cluster mojo, to perform databricks cluster upsert (create or update through recreation).
  */
-@Mojo(name = "upsert-cluster")
+@Mojo(name = "upsert-cluster", requiresProject = false)
 public class UpsertClusterMojo extends BaseDatabricksMojo {
 
     /**
@@ -190,7 +190,7 @@ public class UpsertClusterMojo extends BaseDatabricksMojo {
             while (clusterState != ClusterStateDTO.RUNNING) {
                 getLog().info(String.format("Current cluster state is [%s]. Waiting for RUNNING state", clusterState));
                 // sleep some time to avoid excessive requests to databricks API
-                Thread.sleep(5000);
+                TimeUnit.SECONDS.sleep(15);
                 clusterState = clusterService.getInfo(clusterId).getState();
             }
         }

--- a/src/main/java/com/edmunds/tools/databricks/maven/UpsertClusterMojo.java
+++ b/src/main/java/com/edmunds/tools/databricks/maven/UpsertClusterMojo.java
@@ -64,6 +64,9 @@ public class UpsertClusterMojo extends BaseDatabricksMojo {
 
     public void execute() throws MojoExecutionException {
         ClusterTemplateModel[] cts = getClusterTemplateModels();
+        if (cts.length == 0) {
+            return;
+        }
 
         // Upserting clusters in parallel manner
         ForkJoinPool forkJoinPool = new ForkJoinPool(cts.length);
@@ -132,6 +135,10 @@ public class UpsertClusterMojo extends BaseDatabricksMojo {
     }
 
     protected ClusterTemplateModel[] loadClusterTemplateModelsFromFile(File clustersConfig) throws MojoExecutionException {
+        if (!clustersConfig.exists()) {
+            getLog().info("No clusters config file exists");
+            return new ClusterTemplateModel[]{};
+        }
         ClusterTemplateModel[] cts;
         try {
             cts = ObjectMapperUtils.deserialize(clustersConfig, ClusterTemplateModel[].class);

--- a/src/main/java/com/edmunds/tools/databricks/maven/UpsertClusterMojoNoProject.java
+++ b/src/main/java/com/edmunds/tools/databricks/maven/UpsertClusterMojoNoProject.java
@@ -1,0 +1,31 @@
+package com.edmunds.tools.databricks.maven;
+
+import com.edmunds.tools.databricks.maven.model.ClusterTemplateModel;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+
+/**
+ * Cluster mojo, to perform databricks cluster upsert (create or update through recreation).
+ * <p>
+ * NoProject mojo has been extracted into a separate class
+ * so we have both mojos for non-project execution and for multi-module projects.
+ */
+@Mojo(name = "upsert-cluster-np", requiresProject = false)
+public class UpsertClusterMojoNoProject extends UpsertClusterMojo {
+
+    /**
+     * The databricks cluster json file that contains all of the information for how to create databricks cluster.
+     * Must be specified in case of non-project run.
+     */
+    @Parameter(name = "dbClusterFile", property = "dbClusterFile", required = true)
+    protected File dbClusterFile;
+
+    @Override
+    protected ClusterTemplateModel[] getClusterTemplateModels() throws MojoExecutionException {
+        return loadClusterTemplateModelsFromFile(dbClusterFile);
+    }
+
+}

--- a/src/test/java/com/edmunds/tools/databricks/maven/AbstractUpsertClusterMojoTest.java
+++ b/src/test/java/com/edmunds/tools/databricks/maven/AbstractUpsertClusterMojoTest.java
@@ -1,0 +1,185 @@
+package com.edmunds.tools.databricks.maven;
+
+import com.edmunds.rest.databricks.DTO.AwsAttributesDTO;
+import com.edmunds.rest.databricks.DTO.ClusterInfoDTO;
+import com.edmunds.rest.databricks.DTO.ClusterLibraryStatusesDTO;
+import com.edmunds.rest.databricks.DTO.ClusterLogConfDTO;
+import com.edmunds.rest.databricks.DTO.ClusterStateDTO;
+import com.edmunds.rest.databricks.DTO.ClusterTagDTO;
+import com.edmunds.rest.databricks.DTO.LibraryDTO;
+import com.edmunds.rest.databricks.DTO.LibraryFullStatusDTO;
+import com.edmunds.rest.databricks.request.CreateClusterRequest;
+import com.edmunds.rest.databricks.request.EditClusterRequest;
+import com.google.common.collect.Sets;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static com.edmunds.rest.databricks.DTO.AwsAvailabilityDTO.SPOT_WITH_FALLBACK;
+import static com.edmunds.rest.databricks.DTO.EbsVolumeTypeDTO.GENERAL_PURPOSE_SSD;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public abstract class AbstractUpsertClusterMojoTest<T extends UpsertClusterMojo> extends DatabricksMavenPluginTestHarness {
+
+    protected String GOAL;
+
+    protected T underTest;
+
+    protected abstract void setGoal();
+
+    @BeforeClass
+    public void initClass() throws Exception {
+        super.setUp();
+        setGoal();
+    }
+
+    @BeforeMethod
+    public void beforeMethod() throws Exception {
+        super.beforeMethod();
+    }
+
+    @Test
+    public void test_executeWithDefault_createNewCluster() throws Exception {
+        underTest = getNoOverridesMojo(GOAL);
+        String clusterId = "clusterId";
+
+        when(clusterService.list()).thenReturn(new ClusterInfoDTO[]{});
+        ArgumentCaptor<CreateClusterRequest> reqCaptor = ArgumentCaptor.forClass(CreateClusterRequest.class);
+        when(clusterService.create(reqCaptor.capture())).thenReturn(clusterId);
+
+        ArgumentCaptor<LibraryDTO[]> libCaptor = ArgumentCaptor.forClass(LibraryDTO[].class);
+        doNothing().when(libraryService).install(eq(clusterId), libCaptor.capture());
+
+        underTest.execute();
+        Thread.sleep(100);
+
+        verify(clusterService, times(2)).create(reqCaptor.capture());
+        assertCreateClusterRequestEquality(reqCaptor, Arrays.asList("my-cluster", "my-cluster-2"));
+        verify(clusterService, times(0)).edit(any(EditClusterRequest.class));
+        verify(clusterService, times(0)).restart(clusterId);
+        verify(clusterService, times(0)).getInfo(clusterId);
+
+        verify(libraryService, times(0)).uninstall(eq(clusterId), any(LibraryDTO[].class));
+        verify(libraryService).install(eq(clusterId), libCaptor.capture());
+        Set<String> jarPaths = Sets.newHashSet("dbfs:/Libs/jars/app_sdk_0_1_2-345.jar",
+                "s3://bucket-name/artifacts/com.company.project/my-artifact-name/1.0.132/my-artifact-name-1.0.132.jar");
+        LibraryDTO[] libs = libCaptor.getValue();
+        assertTrue(jarPaths.contains(libs[0].getJar()));
+        assertTrue(jarPaths.contains(libs[1].getJar()));
+    }
+
+    @Test
+    public void test_executeWithOverride_upsertCluster() throws Exception {
+        underTest = getOverridesMojo(GOAL);
+        String clusterId = "clusterId";
+
+        when(clusterService.list()).thenReturn(new ClusterInfoDTO[]{createClusterInfoDTO()});
+        ArgumentCaptor<EditClusterRequest> reqCaptor = ArgumentCaptor.forClass(EditClusterRequest.class);
+        when(clusterService.getInfo(clusterId)).thenReturn(createClusterInfoDTO());
+        when(libraryService.clusterStatus(clusterId)).thenReturn(createClusterLibraryStatusesDTO());
+        ArgumentCaptor<LibraryDTO[]> libCaptor = ArgumentCaptor.forClass(LibraryDTO[].class);
+
+        underTest.execute();
+        Thread.sleep(100);
+
+        verify(clusterService).edit(reqCaptor.capture());
+        verify(clusterService).getInfo(clusterId);
+
+        verify(libraryService).uninstall(eq(clusterId), any(LibraryDTO[].class));
+        verify(libraryService).install(eq(clusterId), libCaptor.capture());
+    }
+
+    @Test
+    public void testCreateArtifactPath_succeedsWithOverrides() throws Exception {
+        underTest = getOverridesMojo(GOAL);
+        assertTrue(getPath().endsWith("databricks-cluster-settings-override.json"));
+    }
+
+    @Test(expectedExceptions = MojoExecutionException.class,
+            expectedExceptionsMessageRegExp = "Failed to parse config.*\"cluster_name\": \"my-cluster-malformed\".*")
+    public void test_executeWithOverride_malformedConfigException() throws Exception {
+        underTest = getOverridesMojo(GOAL, "-malformed");
+        assertTrue(getPath().endsWith("databricks-cluster-settings-malformed.json"));
+
+        underTest.execute();
+    }
+
+    @Test(expectedExceptions = MojoExecutionException.class,
+            expectedExceptionsMessageRegExp = "Failed to parse config: databricks-cluster-settings-missing.json")
+    public void test_executeWithOverride_badConfigPathException() throws Exception {
+        underTest = getOverridesMojo(GOAL, "-missing");
+        assertTrue(getPath().endsWith("databricks-cluster-settings-missing.json"));
+
+        underTest.execute();
+    }
+
+    protected abstract String getPath();
+
+    private void assertCreateClusterRequestEquality(ArgumentCaptor<CreateClusterRequest> reqCaptor, Collection<String> clusterNames) {
+        // mandatory params
+        Map<String, Object> reqData = reqCaptor.getValue().getData();
+        assertEquals(1, reqData.get("num_workers"));
+        assertTrue(clusterNames.contains(reqData.get("cluster_name")));
+        assertEquals("5.2.x-scala2.11", reqData.get("spark_version"));
+        assertEquals("m4.large", reqData.get("node_type_id"));
+        AwsAttributesDTO awsAttributes = (AwsAttributesDTO) reqData.get("aws_attributes");
+        assertEquals(1, awsAttributes.getFirstOnDemand());
+        assertEquals(SPOT_WITH_FALLBACK, awsAttributes.getAvailability());
+        assertEquals("us-east-1c", awsAttributes.getZoneId());
+        assertEquals("yourArn", awsAttributes.getInstanceProfileArn());
+        assertEquals(50, awsAttributes.getSpotBidPricePercent());
+        assertEquals(GENERAL_PURPOSE_SSD, awsAttributes.getEbsVolumeType());
+        assertEquals(1, awsAttributes.getEbsVolumeCount());
+        assertEquals(100, awsAttributes.getEbsVolumeSize());
+        Map<String, String> sparkEnvVars = (Map<String, String>) reqData.get("spark_env_vars");
+        assertEquals("/databricks/python3/bin/python3", sparkEnvVars.get("PYSPARK_PYTHON"));
+        assertEquals(10, reqData.get("autotermination_minutes"));
+        // optional params
+        assertEquals("m4.large", reqData.get("driver_node_type_id"));
+        Map<String, String> sparkConf = (Map<String, String>) reqData.get("spark_conf");
+        assertEquals("true", sparkConf.get("spark.databricks.delta.preview.enabled"));
+        assertEquals("2g", sparkConf.get("spark.driver.maxResultSize"));
+        ClusterLogConfDTO clusterLogConf = (ClusterLogConfDTO) reqData.get("cluster_log_conf");
+        assertNull(clusterLogConf.getDbfs());
+        assertNull(clusterLogConf.getS3());
+        ClusterTagDTO[] customTags = (ClusterTagDTO[]) reqData.get("custom_tags");
+        assertEquals("tag", customTags[0].getKey());
+        assertEquals("value", customTags[0].getValue());
+        String[] sshPublicKeys = (String[]) reqData.get("ssh_public_keys");
+        assertEquals("ssh_key1", sshPublicKeys[0]);
+        assertEquals("ssh_key2", sshPublicKeys[1]);
+    }
+
+    private ClusterInfoDTO createClusterInfoDTO() {
+        ClusterInfoDTO clusterInfoDTO = new ClusterInfoDTO();
+        clusterInfoDTO.setClusterName("my-cluster");
+        clusterInfoDTO.setClusterId("clusterId");
+        clusterInfoDTO.setState(ClusterStateDTO.RUNNING);
+        return clusterInfoDTO;
+    }
+
+    private ClusterLibraryStatusesDTO createClusterLibraryStatusesDTO() {
+        LibraryDTO libraryDTO = new LibraryDTO();
+        libraryDTO.setJar("dbfs:/Libs/jars/app_sdk_0_1_2-345.jar");
+        LibraryFullStatusDTO libraryFullStatusDTO = new LibraryFullStatusDTO();
+        libraryFullStatusDTO.setLibrary(libraryDTO);
+        ClusterLibraryStatusesDTO libraryStatusesDTO = new ClusterLibraryStatusesDTO();
+        libraryStatusesDTO.setLibraryFullStatuses(
+                new LibraryFullStatusDTO[]{libraryFullStatusDTO}
+        );
+        return libraryStatusesDTO;
+    }
+
+}

--- a/src/test/java/com/edmunds/tools/databricks/maven/AbstractUpsertClusterMojoTest.java
+++ b/src/test/java/com/edmunds/tools/databricks/maven/AbstractUpsertClusterMojoTest.java
@@ -10,6 +10,7 @@ import com.edmunds.rest.databricks.DTO.LibraryDTO;
 import com.edmunds.rest.databricks.DTO.LibraryFullStatusDTO;
 import com.edmunds.rest.databricks.request.CreateClusterRequest;
 import com.edmunds.rest.databricks.request.EditClusterRequest;
+import com.edmunds.tools.databricks.maven.model.ClusterTemplateModel;
 import com.google.common.collect.Sets;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.mockito.ArgumentCaptor;
@@ -102,7 +103,7 @@ public abstract class AbstractUpsertClusterMojoTest<T extends UpsertClusterMojo>
     }
 
     @Test
-    public void testCreateArtifactPath_succeedsWithOverrides() throws Exception {
+    public void test_CreateArtifactPath_succeedsWithOverrides() throws Exception {
         underTest = getOverridesMojo(GOAL);
         assertTrue(getPath().endsWith("databricks-cluster-settings-override.json"));
     }
@@ -116,13 +117,15 @@ public abstract class AbstractUpsertClusterMojoTest<T extends UpsertClusterMojo>
         underTest.execute();
     }
 
-    @Test(expectedExceptions = MojoExecutionException.class,
-            expectedExceptionsMessageRegExp = "Failed to parse config: databricks-cluster-settings-missing.json")
-    public void test_executeWithOverride_badConfigPathException() throws Exception {
+    @Test
+    public void test_getClusterSettings_returnsNoFile() throws Exception {
         underTest = getOverridesMojo(GOAL, "-missing");
         assertTrue(getPath().endsWith("databricks-cluster-settings-missing.json"));
 
         underTest.execute();
+        ClusterTemplateModel[] clusterTemplateModels = underTest.getClusterTemplateModels();
+
+        assertEquals(0, clusterTemplateModels.length);
     }
 
     protected abstract String getPath();

--- a/src/test/java/com/edmunds/tools/databricks/maven/UpsertClusterMojoNoProjectTest.java
+++ b/src/test/java/com/edmunds/tools/databricks/maven/UpsertClusterMojoNoProjectTest.java
@@ -1,13 +1,13 @@
 package com.edmunds.tools.databricks.maven;
 
 /**
- * Tests for @{@link UpsertClusterMojo}.
+ * Tests for @{@link UpsertClusterMojoNoProject}.
  */
-public class UpsertClusterMojoTest extends AbstractUpsertClusterMojoTest<UpsertClusterMojo> {
+public class UpsertClusterMojoNoProjectTest extends AbstractUpsertClusterMojoTest<UpsertClusterMojoNoProject> {
 
     @Override
     protected void setGoal() {
-        GOAL = "upsert-cluster";
+        GOAL = "upsert-cluster-np";
     }
 
     @Override

--- a/src/test/resources/unit/basic-test/upsert-cluster-np/databricks-cluster-settings-malformed.json
+++ b/src/test/resources/unit/basic-test/upsert-cluster-np/databricks-cluster-settings-malformed.json
@@ -1,0 +1,11 @@
+[
+  {
+    "num_workers": 1,
+    "cluster_name": "my-cluster-malformed",
+    "spark_version": "5.2.x-scala2.11",
+    "aws_attributes": ["SPOT_WITH_FALLBACK", "us-east-1c"],
+    "node_type_id": "m4.large",
+    "autotermination_minutes": 10,
+    "spark_env_vars": "/databricks/python3/bin/python3"
+  }
+]

--- a/src/test/resources/unit/basic-test/upsert-cluster-np/databricks-cluster-settings-override.json
+++ b/src/test/resources/unit/basic-test/upsert-cluster-np/databricks-cluster-settings-override.json
@@ -1,0 +1,35 @@
+[
+  {
+    "num_workers": 1,
+    "cluster_name": "my-cluster",
+    "spark_version": "5.2.x-scala2.11",
+    "aws_attributes": {
+      "first_on_demand": 1,
+      "availability": "SPOT_WITH_FALLBACK",
+      "zone_id": "us-east-1c",
+      "instance_profile_arn": "yourArn",
+      "spot_bid_price_percent": 50,
+      "ebs_volume_type": "GENERAL_PURPOSE_SSD",
+      "ebs_volume_count": 1,
+      "ebs_volume_size": 100
+    },
+    "node_type_id": "m4.large",
+    "autotermination_minutes": 10,
+    "artifact_paths": [
+      "s3://bucket-name/artifacts/com.company.project/my-artifact-name/1.0.132/my-artifact-name-1.0.132.jar"
+    ],
+    "spark_env_vars": {
+      "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
+    },
+    "driver_node_type_id": "m4.large",
+    "spark_conf": {
+      "spark.databricks.delta.preview.enabled": "true",
+      "spark.driver.maxResultSize": "2g"
+    },
+    "cluster_log_conf": {},
+    "custom_tags": {
+      "tag": "value"
+    },
+    "ssh_public_keys": ["ssh_key1", "ssh_key2"]
+  }
+]

--- a/src/test/resources/unit/basic-test/upsert-cluster-np/databricks-cluster-settings.json
+++ b/src/test/resources/unit/basic-test/upsert-cluster-np/databricks-cluster-settings.json
@@ -1,0 +1,67 @@
+[
+  {
+    "num_workers": 1,
+    "cluster_name": "my-cluster",
+    "spark_version": "5.2.x-scala2.11",
+    "aws_attributes": {
+      "first_on_demand": 1,
+      "availability": "SPOT_WITH_FALLBACK",
+      "zone_id": "us-east-1c",
+      "instance_profile_arn": "yourArn",
+      "spot_bid_price_percent": 50,
+      "ebs_volume_type": "GENERAL_PURPOSE_SSD",
+      "ebs_volume_count": 1,
+      "ebs_volume_size": 100
+    },
+    "node_type_id": "m4.large",
+    "spark_env_vars": {
+      "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
+    },
+    "autotermination_minutes": 10,
+    "artifact_paths": [
+      "s3://bucket-name/artifacts/com.company.project/my-artifact-name/1.0.132/my-artifact-name-1.0.132.jar",
+      "dbfs:/Libs/jars/app_sdk_0_1_2-345.jar",
+      "dbfs:/Libs/wars/app_1_3_2.war"
+    ],
+    "driver_node_type_id": "m4.large",
+    "spark_conf": {
+      "spark.databricks.delta.preview.enabled": "true",
+      "spark.driver.maxResultSize": "2g"
+    },
+    "cluster_log_conf": {},
+    "custom_tags": {
+      "tag": "value"
+    },
+    "ssh_public_keys": ["ssh_key1", "ssh_key2"]
+  },
+  {
+    "num_workers": 1,
+    "cluster_name": "my-cluster-2",
+    "spark_version": "5.2.x-scala2.11",
+    "aws_attributes": {
+      "first_on_demand": 1,
+      "availability": "SPOT_WITH_FALLBACK",
+      "zone_id": "us-east-1c",
+      "instance_profile_arn": "yourArn",
+      "spot_bid_price_percent": 50,
+      "ebs_volume_type": "GENERAL_PURPOSE_SSD",
+      "ebs_volume_count": 1,
+      "ebs_volume_size": 100
+    },
+    "node_type_id": "m4.large",
+    "autotermination_minutes": 10,
+    "spark_env_vars": {
+      "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
+    },
+    "driver_node_type_id": "m4.large",
+    "spark_conf": {
+      "spark.databricks.delta.preview.enabled": "true",
+      "spark.driver.maxResultSize": "2g"
+    },
+    "cluster_log_conf": {},
+    "custom_tags": {
+      "tag": "value"
+    },
+    "ssh_public_keys": ["ssh_key1", "ssh_key2"]
+  }
+]

--- a/src/test/resources/unit/basic-test/upsert-cluster-np/test-no-overrides-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/upsert-cluster-np/test-no-overrides-plugin-config.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2019 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <environment>QA</environment>
+                    <dbClusterFile>databricks-cluster-settings.json</dbClusterFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>upsert-cluster-np</goal>
+                        </goals>
+                        <configuration></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/upsert-cluster-np/test-overrides-plugin-config-malformed.xml
+++ b/src/test/resources/unit/basic-test/upsert-cluster-np/test-overrides-plugin-config-malformed.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2019 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <dbClusterFile>databricks-cluster-settings-malformed.json</dbClusterFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>upsert-cluster-np</goal>
+                        </goals>
+                        <configuration></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/upsert-cluster-np/test-overrides-plugin-config-missing.xml
+++ b/src/test/resources/unit/basic-test/upsert-cluster-np/test-overrides-plugin-config-missing.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2019 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <dbClusterFile>databricks-cluster-settings-missing.json</dbClusterFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>upsert-cluster-np</goal>
+                        </goals>
+                        <configuration></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/basic-test/upsert-cluster-np/test-overrides-plugin-config.xml
+++ b/src/test/resources/unit/basic-test/upsert-cluster-np/test-overrides-plugin-config.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2019 Edmunds.com, Inc.
+  ~
+  ~        Licensed under the Apache License, Version 2.0 (the "License");
+  ~        you may not use this file except in compliance with the License.
+  ~        You may obtain a copy of the License at
+  ~
+  ~            http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~        Unless required by applicable law or agreed to in writing, software
+  ~        distributed under the License is distributed on an "AS IS" BASIS,
+  ~        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~        See the License for the specific language governing permissions and
+  ~        limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>unit-test-group</groupId>
+    <artifactId>unit-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.edmunds</groupId>
+                <artifactId>databricks-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <dbClusterFile>databricks-cluster-settings-override.json</dbClusterFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>upsert-cluster-np</goal>
+                        </goals>
+                        <configuration></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Current plugin version doesn't support out-of-project run scenario.
Also databricks cluster state polling timeout has been increased - for now it makes quite a big log.