### PR TITLE
Issue 57/changing defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.edmunds</groupId>
     <artifactId>databricks-maven-plugin</artifactId>
-    <version>1.6.4-SNAPSHOT</version>
+    <version>1.7.1-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
 

--- a/src/main/java/com/edmunds/tools/databricks/maven/BaseDatabricksJobMojoSettingsInitializer.java
+++ b/src/main/java/com/edmunds/tools/databricks/maven/BaseDatabricksJobMojoSettingsInitializer.java
@@ -99,7 +99,7 @@ public class BaseDatabricksJobMojoSettingsInitializer implements SettingsInitial
         }
 
         // Can't have libraries if its a spark submit task
-        if ((settingsDTO.getLibraries() == null || settingsDTO.getLibraries().length == 0) && settingsDTO.getSparkSubmitTask() == null) {
+        if ((settingsDTO.getLibraries() == null) && settingsDTO.getSparkSubmitTask() == null) {
             settingsDTO.setLibraries(SerializationUtils.clone(defaultSettingsDTO.getLibraries()));
             log.info(String.format("%s|set libraries with %s", jobName, OBJECT_MAPPER.writeValueAsString(defaultSettingsDTO.getLibraries())));
         }

--- a/src/main/resources/default-cluster.json
+++ b/src/main/resources/default-cluster.json
@@ -2,7 +2,7 @@
   {
     "num_workers": 1,
     "cluster_name": "my-cluster",
-    "spark_version": "5.2.x-scala2.11",
+    "spark_version": "6.1.x-scala2.11",
     "aws_attributes": {
       "first_on_demand": 1,
       "availability": "SPOT_WITH_FALLBACK",
@@ -10,17 +10,17 @@
       "instance_profile_arn": "",
       "spot_bid_price_percent": 50,
       "ebs_volume_type": "GENERAL_PURPOSE_SSD",
-      "ebs_volume_count": 1,
-      "ebs_volume_size": 100
+      "ebs_volume_count": 0,
+      "ebs_volume_size": 0
     },
-    "node_type_id": "m4.large",
+    "node_type_id": "m5d.large",
     "spark_env_vars": {
       "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
     },
     "autotermination_minutes": 10,
     "enable_elastic_disk": false,
     "artifact_paths": [],
-    "driver_node_type_id": "m4.large",
+    "driver_node_type_id": "m5d.large",
     "spark_conf": {
       "spark.driver.maxResultSize": "2g"
     },

--- a/src/main/resources/default-job.json
+++ b/src/main/resources/default-job.json
@@ -18,6 +18,7 @@
       //"autotermination_minutes": 30,  autotermination is currently not working  at 2018.06.25
       "enable_elastic_disk": false
     },
+    //Can override by setting to libraries:[]
     "libraries": [
       {
         "jar": "s3://${projectProperties['databricks.repo']}/${projectProperties['databricks.repo.key']}"

--- a/src/main/resources/default-job.json
+++ b/src/main/resources/default-job.json
@@ -3,17 +3,17 @@
   {
     "name": "${groupWithoutCompany}/${artifactId}",
     "new_cluster": {
-      "spark_version": "4.2.x-scala2.11",
+      "spark_version": "6.1.x-scala2.11",
       "aws_attributes": {
         "first_on_demand": 1,
         "availability": "SPOT_WITH_FALLBACK",
         "instance_profile_arn": null,
         "spot_bid_price_percent": 100,
         "ebs_volume_type": "GENERAL_PURPOSE_SSD",
-        "ebs_volume_count": 1,
-        "ebs_volume_size": 100
+        "ebs_volume_count": 0,
+        "ebs_volume_size": 0
       },
-      "node_type_id": "m4.large",
+      "node_type_id": "m5d.large",
       "num_workers": 1,
       //"autotermination_minutes": 30,  autotermination is currently not working  at 2018.06.25
       "enable_elastic_disk": false


### PR DESCRIPTION
- set defaults to be less opinionated, especially when it comes to EBS
- updated other node type defaults
- modified so jobs can be specified without needing libraries

Will create a followup issue to remove the default settings either entirely, or at least have the defaults being able to be overridden with a users own default file, in favor of exception throwing, which is a better long term choice